### PR TITLE
Be safe autoload

### DIFF
--- a/lib/oauth-plugin.rb
+++ b/lib/oauth-plugin.rb
@@ -3,21 +3,13 @@ require 'oauth/signature/hmac/sha1'
 require 'oauth/request_proxy/rack_request'
 require 'oauth/server'
 require 'oauth/controllers/application_controller_methods'
-if Rails::VERSION::MAJOR >= 3
-  require 'oauth/request_proxy/rack_request'
-else
-  require 'oauth/request_proxy/action_controller_request'
-  ActionController::Base.send :include, OAuth::Controllers::ApplicationControllerMethods
-end
+require 'oauth/request_proxy/rack_request'
 
-
-if Rails::VERSION::MAJOR >= 3
-  module OAuth
-    module Plugin
-      class OAuthRailtie < Rails::Railtie
-        initializer "oauth-plugin.configure_rails_initialization" do |app|
-          ActionController::Base.send :include, OAuth::Controllers::ApplicationControllerMethods
-        end
+module OAuth
+  module Plugin
+    class OAuthRailtie < Rails::Railtie
+      initializer "oauth-plugin.configure_rails_initialization" do |app|
+        ActionController::Base.send :include, OAuth::Controllers::ApplicationControllerMethods
       end
     end
   end

--- a/lib/oauth-plugin.rb
+++ b/lib/oauth-plugin.rb
@@ -9,7 +9,9 @@ module OAuth
   module Plugin
     class OAuthRailtie < Rails::Railtie
       initializer "oauth-plugin.configure_rails_initialization" do |app|
-        ActionController::Base.send :include, OAuth::Controllers::ApplicationControllerMethods
+        ActiveSupport.on_load(:action_controller_base) do
+          send :include, OAuth::Controllers::ApplicationControllerMethods
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
support rails 6.

## Problems before the response

I was getting the following warning when starting up with rails6.

```
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper, and ActionText::TagHelper.
```

## Details

corrections were made based on the following.

https://github.com/rails/rails/blob/v5.2.4.5/activesupport/lib/active_support/lazy_load_hooks.rb#L4-L24