### PR TITLE
Fix rspec with new syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in oauth-plugin.gemspec
 gemspec
 
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.10'
+
 require 'rbconfig'
 
 platforms :ruby do

--- a/oauth-plugin.gemspec
+++ b/oauth-plugin.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "growl"
   s.add_development_dependency "rack-test"
 
-  s.add_dependency "multi_json"
   s.add_dependency("oauth", ["< 0.6.0"])
   s.add_dependency("rack")
   s.add_dependency("oauth2", '>= 0.5.0')

--- a/spec/oauth/provider/authorizer_spec.rb
+++ b/spec/oauth/provider/authorizer_spec.rb
@@ -1,202 +1,184 @@
-require 'spec_helper'
-require 'multi_json'
-require 'oauth/provider/authorizer'
-require 'dummy_provider_models'
+# frozen_string_literal: true
+
+require "spec_helper"
+require "oauth/provider/authorizer"
+require "dummy_provider_models"
 
 describe OAuth::Provider::Authorizer do
-
-
   describe "Authorization code" do
-
     describe "should issue code" do
-
       before(:each) do
         @user = double("user")
         @app  = double("app")
-        @code = double("code", :token => "secret auth code")
+        @code = double("code", token: "secret auth code")
 
-        ::ClientApplication.should_receive(:find_by_key!).with('client id').and_return(@app)
+        allow(::ClientApplication).to receive(:find_by_key!).with("client id").and_return(@app)
       end
 
       it "should allow" do
-        ::Oauth2Verifier.should_receive(:create!).with( :client_application=>@app,
-                                                  :user=>@user,
-                                                  :callback_url=>'http://mysite.com/callback',
-                                                  :scope => 'a b').and_return(@code)
+        allow(::Oauth2Verifier).to receive(:create!).with(client_application: @app,
+                                                          user: @user,
+                                                          callback_url: "http://mysite.com/callback",
+                                                          scope: "a b")
+                                                    .and_return(@code)
 
-        @authorizer = OAuth::Provider::Authorizer.new @user, true, :response_type => 'code',
-                                                      :scope => "a b",
-                                                      :client_id => 'client id',
-                                                      :redirect_uri => 'http://mysite.com/callback'
-
-        @authorizer.redirect_uri.should == "http://mysite.com/callback?code=secret%20auth%20code"
-        @authorizer.should be_authorized
-
+        @authorizer = OAuth::Provider::Authorizer.new(@user, true, response_type: "code",
+                                                                   scope: "a b",
+                                                                   client_id: "client id",
+                                                                   redirect_uri: "http://mysite.com/callback")
+        expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback?code=secret%20auth%20code"
+        expect(@authorizer).to be_authorized
       end
 
       it "should include state" do
-        ::Oauth2Verifier.should_receive(:create!).with( :client_application=>@app,
-                                                  :user=>@user,
-                                                  :callback_url=>'http://mysite.com/callback',
-                                                  :scope => 'a b').and_return(@code)
+        allow(::Oauth2Verifier).to receive(:create!).with(client_application: @app,
+                                                          user: @user,
+                                                          callback_url: "http://mysite.com/callback",
+                                                          scope: "a b")
+                                                    .and_return(@code)
 
-        @authorizer = OAuth::Provider::Authorizer.new @user, true, :response_type => 'code',
-                                                      :state => 'customer id',
-                                                      :scope => "a b",
-                                                      :client_id => 'client id',
-                                                      :redirect_uri => 'http://mysite.com/callback'
+        @authorizer = OAuth::Provider::Authorizer.new(@user, true, response_type: "code",
+                                                                   state: "customer id",
+                                                                   scope: "a b",
+                                                                   client_id: "client id",
+                                                                   redirect_uri: "http://mysite.com/callback")
 
-        @authorizer.redirect_uri.should == "http://mysite.com/callback?code=secret%20auth%20code&state=customer%20id"
-        @authorizer.should be_authorized
-
+        expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback?code=secret%20auth%20code&state=customer%20id"
+        expect(@authorizer).to be_authorized
       end
 
       it "should allow query string in callback" do
-        ::Oauth2Verifier.should_receive(:create!).with( :client_application=>@app,
-                                                  :user=>@user,
-                                                  :callback_url=>'http://mysite.com/callback?this=one',
-                                                  :scope => 'a b').and_return(@code)
+        allow(::Oauth2Verifier).to receive(:create!).with(client_application: @app,
+                                                          user: @user,
+                                                          callback_url: "http://mysite.com/callback?this=one",
+                                                          scope: "a b")
+                                                    .and_return(@code)
 
-        @authorizer = OAuth::Provider::Authorizer.new @user, true, :response_type => 'code',
-                                                      :scope => "a b",
-                                                      :client_id => 'client id',
-                                                      :redirect_uri => 'http://mysite.com/callback?this=one'
-        @authorizer.should be_authorized
-        @authorizer.redirect_uri.should == "http://mysite.com/callback?this=one&code=secret%20auth%20code"
+        @authorizer = OAuth::Provider::Authorizer.new(@user, true, response_type: "code",
+                                                                   scope: "a b",
+                                                                   client_id: "client id",
+                                                                   redirect_uri: "http://mysite.com/callback?this=one")
+        expect(@authorizer).to be_authorized
+        expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback?this=one&code=secret%20auth%20code"
       end
     end
-
-
   end
 
   describe "user does not authorize" do
-
     it "should send error" do
-      @authorizer = OAuth::Provider::Authorizer.new @user, false, :response_type => 'code',
-                                                    :scope => "a b",
-                                                    :client_id => 'client id',
-                                                    :redirect_uri => 'http://mysite.com/callback'
+      @authorizer = OAuth::Provider::Authorizer.new(@user, false, response_type: "code",
+                                                                  scope: "a b",
+                                                                  client_id: "client id",
+                                                                  redirect_uri: "http://mysite.com/callback")
 
-      @authorizer.redirect_uri.should == "http://mysite.com/callback?error=access_denied"
-      @authorizer.should_not be_authorized
-
+      expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback?error=access_denied"
+      expect(@authorizer).to_not be_authorized
     end
 
     it "should send error with state and query params in callback" do
-      @authorizer = OAuth::Provider::Authorizer.new @user, false, :response_type => 'code',
-                                                    :scope => "a b",
-                                                    :client_id => 'client id',
-                                                    :redirect_uri=>'http://mysite.com/callback?this=one',
-                                                    :state => "my customer"
+      @authorizer = OAuth::Provider::Authorizer.new(@user, false, response_type: "code",
+                                                                  scope: "a b",
+                                                                  client_id: "client id",
+                                                                  redirect_uri: "http://mysite.com/callback?this=one",
+                                                                  state: "my customer")
 
-      @authorizer.redirect_uri.should == "http://mysite.com/callback?this=one&error=access_denied&state=my%20customer"
-      @authorizer.should_not be_authorized
-
+      expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback?this=one&error=access_denied&state=my%20customer"
+      expect(@authorizer).to_not be_authorized
     end
-
   end
 
   describe "Implict Grant" do
-
     describe "should issue token" do
-
       before(:each) do
         @user = double("user")
         @app  = double("app")
-        @token = double("token", :token => "secret auth code")
+        @token = double("token", token: "secret auth code")
 
-        ::ClientApplication.should_receive(:find_by_key!).with('client id').and_return(@app)
+        allow(::ClientApplication).to receive(:find_by_key!).with("client id").and_return(@app)
       end
 
       it "should allow" do
-        ::Oauth2Token.should_receive(:create!).with( :client_application=>@app,
-                                                  :user=>@user,
-                                                  :callback_url=>'http://mysite.com/callback',
-                                                  :scope => 'a b').and_return(@token)
+        allow(::Oauth2Token).to receive(:create!).with(client_application: @app,
+                                                       user: @user,
+                                                       callback_url: "http://mysite.com/callback",
+                                                       scope: "a b")
+                                                 .and_return(@token)
 
-        @authorizer = OAuth::Provider::Authorizer.new @user, true, :response_type => 'token',
-                                                      :scope => "a b",
-                                                      :client_id => 'client id',
-                                                      :redirect_uri => 'http://mysite.com/callback'
+        @authorizer = OAuth::Provider::Authorizer.new(@user, true, response_type: "token",
+                                                                   scope: "a b",
+                                                                   client_id: "client id",
+                                                                   redirect_uri: "http://mysite.com/callback")
 
-        @authorizer.redirect_uri.should == "http://mysite.com/callback#access_token=secret%20auth%20code"
-        @authorizer.should be_authorized
-
+        expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback#access_token=secret%20auth%20code"
+        expect(@authorizer).to be_authorized
       end
 
       it "should include state" do
-        ::Oauth2Token.should_receive(:create!).with( :client_application=>@app,
-                                                  :user=>@user,
-                                                  :callback_url=>'http://mysite.com/callback',
-                                                  :scope => 'a b').and_return(@token)
+        allow(::Oauth2Token).to receive(:create!).with(client_application: @app,
+                                                       user: @user,
+                                                       callback_url: "http://mysite.com/callback",
+                                                       scope: "a b")
+                                                 .and_return(@token)
 
-        @authorizer = OAuth::Provider::Authorizer.new @user, true, :response_type => 'token',
-                                                      :state => 'customer id',
-                                                      :scope => "a b",
-                                                      :client_id => 'client id',
-                                                      :redirect_uri => 'http://mysite.com/callback'
+        @authorizer = OAuth::Provider::Authorizer.new(@user, true, response_type: "token",
+                                                                   state: "customer id",
+                                                                   scope: "a b",
+                                                                   client_id: "client id",
+                                                                   redirect_uri: "http://mysite.com/callback")
 
-        @authorizer.redirect_uri.should == "http://mysite.com/callback#access_token=secret%20auth%20code&state=customer%20id"
-        @authorizer.should be_authorized
-
+        expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback#access_token=secret%20auth%20code&state=customer%20id"
+        expect(@authorizer).to be_authorized
       end
 
       it "should allow query string in callback" do
-        ::Oauth2Token.should_receive(:create!).with( :client_application=>@app,
-                                                  :user=>@user,
-                                                  :callback_url=>'http://mysite.com/callback?this=one',
-                                                  :scope => 'a b').and_return(@token)
+        allow(::Oauth2Token).to receive(:create!).with(client_application: @app,
+                                                       user: @user,
+                                                       callback_url: "http://mysite.com/callback?this=one",
+                                                       scope: "a b")
+                                                 .and_return(@token)
 
-        @authorizer = OAuth::Provider::Authorizer.new @user, true, :response_type => 'token',
-                                                      :scope => "a b",
-                                                      :client_id => 'client id',
-                                                      :redirect_uri => 'http://mysite.com/callback?this=one'
-        @authorizer.should be_authorized
-        @authorizer.redirect_uri.should == "http://mysite.com/callback?this=one#access_token=secret%20auth%20code"
+        @authorizer = OAuth::Provider::Authorizer.new(@user, true, response_type: "token",
+                                                                   scope: "a b",
+                                                                   client_id: "client id",
+                                                                   redirect_uri: "http://mysite.com/callback?this=one")
+        expect(@authorizer).to be_authorized
+        expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback?this=one#access_token=secret%20auth%20code"
       end
     end
-
-
   end
 
   describe "user does not authorize" do
-
     it "should send error" do
-      @authorizer = OAuth::Provider::Authorizer.new @user, false, :response_type => 'token',
-                                                    :scope => "a b",
-                                                    :client_id => 'client id',
-                                                    :redirect_uri => 'http://mysite.com/callback'
+      @authorizer = OAuth::Provider::Authorizer.new(@user, false, response_type: "token",
+                                                                  scope: "a b",
+                                                                  client_id: "client id",
+                                                                  redirect_uri: "http://mysite.com/callback")
 
-      @authorizer.redirect_uri.should == "http://mysite.com/callback#error=access_denied"
-      @authorizer.should_not be_authorized
-
+      expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback#error=access_denied"
+      expect(@authorizer).to_not be_authorized
     end
 
     it "should send error with state and query params in callback" do
-      @authorizer = OAuth::Provider::Authorizer.new @user, false, :response_type => 'token',
-                                                    :scope => "a b",
-                                                    :client_id => 'client id',
-                                                    :redirect_uri=>'http://mysite.com/callback?this=one',
-                                                    :state => "my customer"
+      @authorizer = OAuth::Provider::Authorizer.new(@user, false, response_type: "token",
+                                                                  scope: "a b",
+                                                                  client_id: "client id",
+                                                                  redirect_uri: "http://mysite.com/callback?this=one",
+                                                                  state: "my customer")
 
-      @authorizer.redirect_uri.should == "http://mysite.com/callback?this=one#error=access_denied&state=my%20customer"
-      @authorizer.should_not be_authorized
-
+      expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback?this=one#error=access_denied&state=my%20customer"
+      expect(@authorizer).to_not be_authorized
     end
-
   end
 
   it "should handle unsupported response type" do
     @user = double("user")
 
-    @authorizer = OAuth::Provider::Authorizer.new @user, false, :response_type => 'my new',
-                                                  :scope => "a b",
-                                                  :client_id => 'client id',
-                                                  :redirect_uri => 'http://mysite.com/callback'
+    @authorizer = OAuth::Provider::Authorizer.new(@user, false, response_type: "my new",
+                                                                scope: "a b",
+                                                                client_id: "client id",
+                                                                redirect_uri: "http://mysite.com/callback")
 
-    @authorizer.redirect_uri.should == "http://mysite.com/callback#error=unsupported_response_type"
-    @authorizer.should_not be_authorized
-
+    expect(@authorizer.redirect_uri).to eq "http://mysite.com/callback#error=unsupported_response_type"
+    expect(@authorizer).to_not be_authorized
   end
-
 end

--- a/spec/rack/oauth_filter_spec.rb
+++ b/spec/rack/oauth_filter_spec.rb
@@ -1,9 +1,11 @@
-require 'spec_helper'
-require 'rack/test'
-require 'oauth/rack/oauth_filter'
-require 'multi_json'
-require 'forwardable'
-require 'dummy_provider_models'
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rack/test"
+require "oauth/rack/oauth_filter"
+require "forwardable"
+require "dummy_provider_models"
+require "json"
 
 class OAuthEcho
   def call(env)
@@ -12,7 +14,7 @@ class OAuthEcho
     response[:client_application] = env["oauth.client_application"].key if env["oauth.client_application"]
     response[:oauth_version]      = env["oauth.version"]                if env["oauth.version"]
     response[:strategies]         = env["oauth.strategies"]             if env["oauth.strategies"]
-     [200, { "Accept" => "application/json" }, [MultiJson.encode(response)]]
+    [200, { "Accept": "application/json" }, [response.to_json]]
   end
 end
 
@@ -24,68 +26,68 @@ describe OAuth::Rack::OAuthFilter do
   end
 
   it "should pass through without oauth" do
-    get '/'
-    last_response.should be_ok
-    response = MultiJson.decode(last_response.body)
-    response.should == {}
+    get "/"
+    expect(last_response.status).to eq 200
+    response = JSON.parse(last_response.body, symbolize_names: true)
+    expect(response).to eq({})
   end
 
-  describe 'OAuth1' do
-    describe 'with optional white space' do
+  describe "OAuth1" do
+    describe "with optional white space" do
       it "should sign with consumer" do
-        get '/',{},{"HTTP_AUTHORIZATION"=>'OAuth oauth_consumer_key="my_consumer", oauth_nonce="amrLDyFE2AMztx5fOYDD1OEqWps6Mc2mAR5qyO44Rj8", oauth_signature="KCSg0RUfVFUcyhrgJo580H8ey0c%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1295039581", oauth_version="1.0"'}
-        last_response.should be_ok
-        response = MultiJson.decode(last_response.body)
-        response.should == {"client_application" => "my_consumer", "oauth_version"=>1, "strategies"=>["two_legged"]}
+        get "/", {}, { "HTTP_AUTHORIZATION" => 'OAuth oauth_consumer_key="my_consumer", oauth_nonce="amrLDyFE2AMztx5fOYDD1OEqWps6Mc2mAR5qyO44Rj8", oauth_signature="KCSg0RUfVFUcyhrgJo580H8ey0c%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1295039581", oauth_version="1.0"' }
+        expect(last_response.status).to eq 200
+        response = JSON.parse(last_response.body, symbolize_names: true)
+        expect(response).to eq({ "client_application": "my_consumer", "oauth_version": 1, "strategies": ["two_legged"] })
       end
 
       it "should sign with oauth 1 access token" do
         client_application = ClientApplication.new "my_consumer"
-        ClientApplication.stub!(:find_by_key).and_return(client_application)
-        client_application.tokens.stub!(:where).and_return([AccessToken.new("my_token")])
-        get '/',{},{"HTTP_AUTHORIZATION"=>'OAuth oauth_consumer_key="my_consumer", oauth_nonce="oiFHXoN0172eigBBUfgaZLdQg7ycGekv8iTdfkCStY", oauth_signature="y35B2DqTWaNlzNX0p4wv%2FJAGzg8%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1295040394", oauth_token="my_token", oauth_version="1.0"'}
-        last_response.should be_ok
-        response = MultiJson.decode(last_response.body)
-        response.should == {"client_application" => "my_consumer", "oauth_token"=>"my_token","oauth_version"=>1, "strategies"=>["oauth10_token","token","oauth10_access_token"]}
+        allow(ClientApplication).to receive(:find_by_key).and_return(client_application)
+        allow(client_application.tokens).to receive(:where).and_return([AccessToken.new("my_token")])
+        get "/", {}, { "HTTP_AUTHORIZATION" => 'OAuth oauth_consumer_key="my_consumer", oauth_nonce="oiFHXoN0172eigBBUfgaZLdQg7ycGekv8iTdfkCStY", oauth_signature="y35B2DqTWaNlzNX0p4wv%2FJAGzg8%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1295040394", oauth_token="my_token", oauth_version="1.0"' }
+        expect(last_response.status).to eq 200
+        response = JSON.parse(last_response.body, symbolize_names: true)
+        expect(response).to eq({ "client_application": "my_consumer", "oauth_token": "my_token", "oauth_version": 1, "strategies": ["oauth10_token", "token", "oauth10_access_token"] })
       end
 
       it "should sign with oauth 1 request token" do
         client_application = ClientApplication.new "my_consumer"
-        ClientApplication.stub!(:find_by_key).and_return(client_application)
-        client_application.tokens.stub!(:where).and_return([RequestToken.new("my_token")])
-        get '/',{},{"HTTP_AUTHORIZATION"=>'OAuth oauth_consumer_key="my_consumer", oauth_nonce="oiFHXoN0172eigBBUfgaZLdQg7ycGekv8iTdfkCStY", oauth_signature="y35B2DqTWaNlzNX0p4wv%2FJAGzg8%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1295040394", oauth_token="my_token", oauth_version="1.0"'}
-        last_response.should be_ok
-        response = MultiJson.decode(last_response.body)
-        response.should == {"client_application" => "my_consumer", "oauth_token"=>"my_token","oauth_version"=>1, "strategies"=>["oauth10_token","oauth10_request_token"]}
+        allow(ClientApplication).to receive(:find_by_key).and_return(client_application)
+        allow(client_application.tokens).to receive(:where).and_return([RequestToken.new("my_token")])
+        get "/", {}, { "HTTP_AUTHORIZATION" => 'OAuth oauth_consumer_key="my_consumer", oauth_nonce="oiFHXoN0172eigBBUfgaZLdQg7ycGekv8iTdfkCStY", oauth_signature="y35B2DqTWaNlzNX0p4wv%2FJAGzg8%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1295040394", oauth_token="my_token", oauth_version="1.0"' }
+        expect(last_response.status).to eq 200
+        response = JSON.parse(last_response.body, symbolize_names: true)
+        expect(response).to eq({ "client_application": "my_consumer", "oauth_token": "my_token","oauth_version": 1, "strategies": ["oauth10_token", "oauth10_request_token"]})
       end
     end
 
-    describe 'without optional white space' do
+    describe "without optional white space" do
       it "should sign with consumer" do
-        get '/',{},{"HTTP_AUTHORIZATION"=>'OAuth oauth_consumer_key="my_consumer",oauth_nonce="amrLDyFE2AMztx5fOYDD1OEqWps6Mc2mAR5qyO44Rj8",oauth_signature="KCSg0RUfVFUcyhrgJo580H8ey0c%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1295039581",oauth_version="1.0"'}
-        last_response.should be_ok
-        response = MultiJson.decode(last_response.body)
-        response.should == {"client_application" => "my_consumer", "oauth_version"=>1, "strategies"=>["two_legged"]}
+        get "/", {}, { "HTTP_AUTHORIZATION" => 'OAuth oauth_consumer_key="my_consumer",oauth_nonce="amrLDyFE2AMztx5fOYDD1OEqWps6Mc2mAR5qyO44Rj8",oauth_signature="KCSg0RUfVFUcyhrgJo580H8ey0c%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1295039581",oauth_version="1.0"' }
+        expect(last_response.status).to eq 200
+        response = JSON.parse(last_response.body, symbolize_names: true)
+        expect(response).to eq({ "client_application": "my_consumer", "oauth_version": 1, "strategies": ["two_legged"] })
       end
 
       it "should sign with oauth 1 access token" do
         client_application = ClientApplication.new "my_consumer"
-        ClientApplication.stub!(:find_by_key).and_return(client_application)
-        client_application.tokens.stub!(:where).and_return([AccessToken.new("my_token")])
-        get '/',{},{"HTTP_AUTHORIZATION"=>'OAuth oauth_consumer_key="my_consumer",oauth_nonce="oiFHXoN0172eigBBUfgaZLdQg7ycGekv8iTdfkCStY",oauth_signature="y35B2DqTWaNlzNX0p4wv%2FJAGzg8%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1295040394",oauth_token="my_token",oauth_version="1.0"'}
-        last_response.should be_ok
-        response = MultiJson.decode(last_response.body)
-        response.should == {"client_application" => "my_consumer", "oauth_token"=>"my_token","oauth_version"=>1, "strategies"=>["oauth10_token","token","oauth10_access_token"]}
+        allow(ClientApplication).to receive(:find_by_key).and_return(client_application)
+        allow(client_application.tokens).to receive(:where).and_return([AccessToken.new("my_token")])
+        get "/", {}, { "HTTP_AUTHORIZATION" => 'OAuth oauth_consumer_key="my_consumer",oauth_nonce="oiFHXoN0172eigBBUfgaZLdQg7ycGekv8iTdfkCStY",oauth_signature="y35B2DqTWaNlzNX0p4wv%2FJAGzg8%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1295040394",oauth_token="my_token",oauth_version="1.0"' }
+        expect(last_response.status).to eq 200
+        response = JSON.parse(last_response.body, symbolize_names: true)
+        expect(response).to eq({ "client_application": "my_consumer", "oauth_token": "my_token", "oauth_version": 1, "strategies": ["oauth10_token","token","oauth10_access_token"] })
       end
 
       it "should sign with oauth 1 request token" do
         client_application = ClientApplication.new "my_consumer"
-        ClientApplication.stub!(:find_by_key).and_return(client_application)
-        client_application.tokens.stub!(:where).and_return([RequestToken.new("my_token")])
-        get '/',{},{"HTTP_AUTHORIZATION"=>'OAuth oauth_consumer_key="my_consumer",oauth_nonce="oiFHXoN0172eigBBUfgaZLdQg7ycGekv8iTdfkCStY",oauth_signature="y35B2DqTWaNlzNX0p4wv%2FJAGzg8%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1295040394",oauth_token="my_token",oauth_version="1.0"'}
-        last_response.should be_ok
-        response = MultiJson.decode(last_response.body)
-        response.should == {"client_application" => "my_consumer", "oauth_token"=>"my_token","oauth_version"=>1, "strategies"=>["oauth10_token","oauth10_request_token"]}
+        allow(ClientApplication).to receive(:find_by_key).and_return(client_application)
+        allow(client_application.tokens).to receive(:where).and_return([RequestToken.new("my_token")])
+        get "/", {}, { "HTTP_AUTHORIZATION" => 'OAuth oauth_consumer_key="my_consumer",oauth_nonce="oiFHXoN0172eigBBUfgaZLdQg7ycGekv8iTdfkCStY",oauth_signature="y35B2DqTWaNlzNX0p4wv%2FJAGzg8%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1295040394",oauth_token="my_token",oauth_version="1.0"' }
+        expect(last_response.status).to eq 200
+        response = JSON.parse(last_response.body, symbolize_names: true)
+        expect(response).to eq({ "client_application": "my_consumer", "oauth_token": "my_token", "oauth_version": 1, "strategies": ["oauth10_token","oauth10_request_token"] })
       end
     end
   end
@@ -94,28 +96,28 @@ describe OAuth::Rack::OAuthFilter do
     describe "token given through a HTTP Auth Header" do
       context "authorized and non-invalidated token" do
         it "authenticates" do
-          get '/', {}, { "HTTP_AUTHORIZATION" => "Bearer valid_token" }
-          last_response.should be_ok
-          response = MultiJson.decode(last_response.body)
-          response.should == { "oauth_token" => "valid_token", "oauth_version" => 2, "strategies"=> ["oauth20_token", "token"] }
+          get "/", {}, { "HTTP_AUTHORIZATION" => "Bearer valid_token" }
+          expect(last_response.status).to eq 200
+          response = JSON.parse(last_response.body, symbolize_names: true)
+          expect(response).to eq({ "oauth_token": "valid_token", "oauth_version": 2, "strategies": ["oauth20_token", "token"] })
         end
       end
 
       context "non-authorized token" do
         it "doesn't authenticate" do
-          get '/', {}, { "HTTP_AUTHORIZATION" => "Bearer not_authorized" }
-          last_response.should be_ok
-          response = MultiJson.decode(last_response.body)
-          response.should == {}
+          get "/", {}, { "HTTP_AUTHORIZATION" => "Bearer not_authorized" }
+          expect(last_response.status).to eq 200
+          response = JSON.parse(last_response.body, symbolize_names: true)
+          expect(response).to eq({})
         end
       end
 
       context "authorized and invalidated token" do
         it "doesn't authenticate with an invalidated token" do
-          get '/', {}, { "HTTP_AUTHORIZATION" => "Bearer invalidated" }
-          last_response.should be_ok
-          response = MultiJson.decode(last_response.body)
-          response.should == {}
+          get "/", {}, { "HTTP_AUTHORIZATION" => "Bearer invalidated" }
+          expect(last_response.status).to eq 200
+          response = JSON.parse(last_response.body, symbolize_names: true)
+          expect(response).to eq({})
         end
       end
     end
@@ -124,28 +126,28 @@ describe OAuth::Rack::OAuthFilter do
       describe "token given through a HTTP Auth Header" do
         context "authorized and non-invalidated token" do
           it "authenticates" do
-            get '/', {}, { "HTTP_AUTHORIZATION" => "OAuth valid_token" }
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == { "oauth_token" => "valid_token", "oauth_version" => 2, "strategies"=> ["oauth20_token", "token"] }
+            get "/", {}, { "HTTP_AUTHORIZATION" => "OAuth valid_token" }
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({ "oauth_token": "valid_token", "oauth_version": 2, "strategies": ["oauth20_token", "token"] })
           end
         end
 
         context "non-authorized token" do
           it "doesn't authenticate" do
-            get '/', {}, { "HTTP_AUTHORIZATION" => "OAuth not_authorized" }
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == {}
+            get "/", {}, { "HTTP_AUTHORIZATION" => "OAuth not_authorized" }
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({})
           end
         end
 
         context "authorized and invalidated token" do
           it "doesn't authenticate with an invalidated token" do
-            get '/', {}, { "HTTP_AUTHORIZATION" => "OAuth invalidated" }
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == {}
+            get "/", {}, { "HTTP_AUTHORIZATION" => "OAuth invalidated" }
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({})
           end
         end
       end
@@ -154,59 +156,59 @@ describe OAuth::Rack::OAuthFilter do
     describe "token given through a HTTP Auth Header following the OAuth2 pre draft" do
       context "authorized and non-invalidated token" do
         it "authenticates" do
-          get '/', {}, { "HTTP_AUTHORIZATION" => "Token valid_token" }
-          last_response.should be_ok
-          response = MultiJson.decode(last_response.body)
-          response.should == { "oauth_token" => "valid_token", "oauth_version" => 2, "strategies"=> ["oauth20_token", "token"] }
+          get "/", {}, { "HTTP_AUTHORIZATION" => "Token valid_token" }
+          expect(last_response.status).to eq 200
+          response = JSON.parse(last_response.body, symbolize_names: true)
+          expect(response).to eq({ "oauth_token": "valid_token", "oauth_version": 2, "strategies": ["oauth20_token", "token"] })
         end
       end
 
       context "non-authorized token" do
         it "doesn't authenticate" do
-          get '/', {}, { "HTTP_AUTHORIZATION" => "Token not_authorized" }
-          last_response.should be_ok
-          response = MultiJson.decode(last_response.body)
-          response.should == {}
+          get "/", {}, { "HTTP_AUTHORIZATION" => "Token not_authorized" }
+          expect(last_response.status).to eq 200
+          response = JSON.parse(last_response.body, symbolize_names: true)
+          expect(response).to eq({})
         end
       end
 
       context "authorized and invalidated token" do
         it "doesn't authenticate with an invalidated token" do
-          get '/', {}, { "HTTP_AUTHORIZATION" => "Token invalidated" }
-          last_response.should be_ok
-          response = MultiJson.decode(last_response.body)
-          response.should == {}
+          get "/", {}, { "HTTP_AUTHORIZATION" => "Token invalidated" }
+          expect(last_response.status).to eq 200
+          response = JSON.parse(last_response.body, symbolize_names: true)
+          expect(response).to eq({})
         end
       end
     end
 
-    ['bearer_token', 'access_token', 'oauth_token'].each do |name|
+    ["bearer_token", "access_token", "oauth_token"].each do |name|
       describe "token given through the query parameter '#{name}'" do
         context "authorized and non-invalidated token" do
           it "authenticates" do
             get "/?#{name}=valid_token"
 
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == { "oauth_token" => "valid_token", "oauth_version" => 2, "strategies"=> ["oauth20_token", "token"] }
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({ "oauth_token": "valid_token", "oauth_version": 2, "strategies": ["oauth20_token", "token"] })
           end
         end
 
         context "non-authorized token" do
           it "doesn't authenticate" do
             get "/?#{name}=not_authorized"
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == {}
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({})
           end
         end
 
         context "authorized and invalidated token" do
           it "doesn't authenticate with an invalidated token" do
             get "/?#{name}=invalidated"
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == {}
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({})
           end
         end
       end
@@ -214,28 +216,28 @@ describe OAuth::Rack::OAuthFilter do
       describe "token given through the post parameter '#{name}'" do
         context "authorized and non-invalidated token" do
           it "authenticates" do
-            post '/', name => 'valid_token'
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == { "oauth_token" => "valid_token", "oauth_version" => 2, "strategies"=> ["oauth20_token", "token"] }
+            post "/", name => "valid_token"
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({ "oauth_token": "valid_token", "oauth_version": 2, "strategies": ["oauth20_token", "token"] })
           end
         end
 
         context "non-authorized token" do
           it "doesn't authenticate" do
-            post '/', name => 'not_authorized'
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == {}
+            post "/", name => "not_authorized"
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({})
           end
         end
 
         context "authorized and invalidated token" do
           it "doesn't authenticate with an invalidated token" do
-            post '/', name => 'invalidated'
-            last_response.should be_ok
-            response = MultiJson.decode(last_response.body)
-            response.should == {}
+            post "/", name => "invalidated"
+            expect(last_response.status).to eq 200
+            response = JSON.parse(last_response.body, symbolize_names: true)
+            expect(response).to eq({})
           end
         end
       end


### PR DESCRIPTION
Hi CrowdWorks.

Fix rspec with new syntax.
Please check in the following environment.

```sh
$ ruby -v
ruby 2.6.8p205 (2021-07-07 revision 67951) [x86_64-darwin20]
$ bundler -v
Bundler version 2.2.21

$ bundle install
$ bundle exec rspec
```