### PR TITLE
Fix URI escape to Addressable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in oauth-plugin.gemspec
 gemspec
 
+# Addressable is an alternative implementation to the URI
+# implementation that is part of Ruby's standard library.
+# Addressable closely conforms to RFC 3986, RFC 3987, and RFC 6570 (level 4).
 gem 'addressable', '~> 2.8.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.10'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in oauth-plugin.gemspec
 gemspec
 
+gem 'addressable', '~> 2.8.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.10'
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -20,6 +20,8 @@ There are several changes to the latest OAuth 2.0 spec which requires a couple o
 
 https://github.com/pelle/oauth-plugin/blob/master/lib/generators/active_record/oauth_provider_templates/oauth2_token.rb
 
+  require "addressable/uri"
+
   class Oauth2Token < AccessToken
     attr_accessor :state
     def as_json(options={})
@@ -30,9 +32,9 @@ https://github.com/pelle/oauth-plugin/blob/master/lib/generators/active_record/o
 
     def to_query
       q = "access_token=#{token}&token_type=bearer"
-      q << "&state=#{URI.escape(state)}" if @state
+      q << "&state=#{Addressable::URI.encode(state)}" if @state
       q << "&expires_in=#{expires_in}" if expires_at
-      q << "&scope=#{URI.escape(scope)}" if scope
+      q << "&scope=#{Addressable::URI.encode(scope)}" if scope
       q
     end
 
@@ -43,6 +45,8 @@ https://github.com/pelle/oauth-plugin/blob/master/lib/generators/active_record/o
 
 
 https://github.com/pelle/oauth-plugin/blob/master/lib/generators/active_record/oauth_provider_templates/oauth2_verifier.rb
+
+  require "addressable/uri"
 
   class Oauth2Verifier < OauthToken
     validates_presence_of :user
@@ -66,7 +70,7 @@ https://github.com/pelle/oauth-plugin/blob/master/lib/generators/active_record/o
 
     def to_query
       q = "code=#{token}"
-      q << "&state=#{URI.escape(state)}" if @state
+      q << "&state=#{Addressable::URI.encode(state)}" if @state
       q
     end
 

--- a/generators/oauth_provider/templates/oauth2_token.rb
+++ b/generators/oauth_provider/templates/oauth2_token.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class Oauth2Token < AccessToken
   attr_accessor :state
   def as_json(options={})
@@ -8,9 +10,9 @@ class Oauth2Token < AccessToken
 
   def to_query
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{Addressable::URI.encode(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{URI.escape(scope)}" if scope
+    q << "&scope=#{Addressable::URI.encode(scope)}" if scope
     q
   end
 

--- a/generators/oauth_provider/templates/oauth2_verifier.rb
+++ b/generators/oauth_provider/templates/oauth2_verifier.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class Oauth2Verifier < OauthToken
   validates_presence_of :user
   attr_accessor :state
@@ -20,7 +22,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{Addressable::URI.encode(state)}" if @state
     q
   end
 

--- a/lib/generators/active_record/oauth_provider_templates/oauth2_token.rb
+++ b/lib/generators/active_record/oauth_provider_templates/oauth2_token.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class Oauth2Token < AccessToken
   attr_accessor :state
   def as_json(options={})
@@ -8,9 +10,9 @@ class Oauth2Token < AccessToken
 
   def to_query
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{Addressable::URI.encode(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{URI.escape(scope)}" if scope
+    q << "&scope=#{Addressable::URI.encode(scope)}" if scope
     q
   end
 

--- a/lib/generators/active_record/oauth_provider_templates/oauth2_verifier.rb
+++ b/lib/generators/active_record/oauth_provider_templates/oauth2_verifier.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class Oauth2Verifier < OauthToken
   validates_presence_of :user
   attr_accessor :state
@@ -20,7 +22,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{Addressable::URI.encode(state)}" if @state
     q
   end
 

--- a/lib/generators/mongoid/oauth_provider_templates/oauth2_token.rb
+++ b/lib/generators/mongoid/oauth_provider_templates/oauth2_token.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class Oauth2Token < AccessToken
   attr_accessor :state
   def as_json(options={})
@@ -8,9 +10,9 @@ class Oauth2Token < AccessToken
 
   def to_query
     q = "access_token=#{token}&token_type=bearer"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{Addressable::URI.encode(state)}" if @state
     q << "&expires_in=#{expires_in}" if expires_at
-    q << "&scope=#{URI.escape(scope)}" if scope
+    q << "&scope=#{Addressable::URI.encode(scope)}" if scope
     q
   end
 

--- a/lib/generators/mongoid/oauth_provider_templates/oauth2_verifier.rb
+++ b/lib/generators/mongoid/oauth_provider_templates/oauth2_verifier.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class Oauth2Verifier < OauthToken
   validates_presence_of :user
   attr_accessor :state
@@ -20,7 +22,7 @@ class Oauth2Verifier < OauthToken
 
   def to_query
     q = "code=#{token}"
-    q << "&state=#{URI.escape(state)}" if @state
+    q << "&state=#{Addressable::URI.encode(state)}" if @state
     q
   end
 

--- a/lib/oauth/provider/authorizer.rb
+++ b/lib/oauth/provider/authorizer.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'addressable/uri'
 
 module OAuth
   module Provider
@@ -69,7 +70,7 @@ module OAuth
 
       def encode_response
         response.map do |k, v|
-          [URI.escape(k.to_s),URI.escape(v)] * "="
+          [Addressable::URI.encode(k.to_s), Addressable::URI.encode(v)] * "="
         end * "&"
       end
 

--- a/oauth-plugin.gemspec
+++ b/oauth-plugin.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_dependency("oauth", ["< 0.6.0"])
   s.add_dependency("rack")
   s.add_dependency("oauth2", '>= 0.5.0')
+  s.add_dependency("addressable", '~> 2.8.0')
 end


### PR DESCRIPTION
URI.escape is deprecated in Ruby 2.7.
URI.escape has been modified to use "Addressable" which conforms to the RFC-3896 specification.
